### PR TITLE
Added the ablity to transfer blendfiles.

### DIFF
--- a/makeskin/extraproperties.py
+++ b/makeskin/extraproperties.py
@@ -65,6 +65,7 @@ def extraProperties():
     bpy.types.Object.MhMsDepthless = BoolProperty(name="Depthless", description="If the material is to be rendered as having no depth. It is unlikely you want this.", default=False)
     bpy.types.Object.MhMsSSSEnable = BoolProperty(name="SSS Enable", description="If the material is to be rendered with sub surface scattering.", default=False)
     bpy.types.Object.MhMsUseLit = BoolProperty(name="Use Litsphere", description="Use the litsphere shader when rendering material in MakeHuman. This does not have any effect on materials outside MakeHuman", default=True)
+    bpy.types.Object.MhMsWriteBlendMaterial = BoolProperty(name="Write Blend material", description="Stores the second material on the active object in a blend file", default=False)
 
     # Options
     bpy.types.Object.MhMsLitsphere = bpy.props.EnumProperty(items=_litspheres, name="Litsphere", description=_litsphereDescription, default="leather")

--- a/makeskin/makeskin.py
+++ b/makeskin/makeskin.py
@@ -54,5 +54,7 @@ class MHS_PT_MakeSkinPanel(bpy.types.Panel):
             writeBox.prop(obj, 'MhMsUseLit', text='Use litsphere')
             writeBox.prop(obj, 'MhMsLitsphere', text='Litsphere texture')
 
+            writeBox.prop(obj, 'MhMsWriteBlendMaterial', text='Save Blender material')
+
             writeBox.operator("makeskin.write_material", text="Save material")
 

--- a/makeskin/material.py
+++ b/makeskin/material.py
@@ -155,7 +155,8 @@ class MHMat:
             "displacementmapTexture",
             "specularmapTexture",
             "transparencymapTexture",
-            "aomapTexture"]
+            "aomapTexture",
+            "blendMaterial"]
 
         self._intensityKeys = [
 

--- a/makeskin/operators/importmaterial.py
+++ b/makeskin/operators/importmaterial.py
@@ -42,7 +42,8 @@ class MHS_OT_ImportMaterialOperator(bpy.types.Operator, ImportHelper):
         
         ##- Load Blend -##
         path = mhmat.settings["blendMaterial"]
-        blendMatLoad(path)
+        if path:
+            blendMatLoad(path)
 
         self.report({'INFO'}, "Material imported")
         return {'FINISHED'}

--- a/makeskin/operators/importmaterial.py
+++ b/makeskin/operators/importmaterial.py
@@ -39,6 +39,10 @@ class MHS_OT_ImportMaterialOperator(bpy.types.Operator, ImportHelper):
 
         mhmat = MHMat(fileName=self.filepath)
         mhmat.assignAsNodesMaterialForObj(obj)
+        
+        ##- Load Blend -##
+        path = mhmat.settings["blendMaterial"]
+        blendMatLoad(path)
 
         self.report({'INFO'}, "Material imported")
         return {'FINISHED'}

--- a/makeskin/utils.py
+++ b/makeskin/utils.py
@@ -14,3 +14,55 @@ def createEmptyMaterial(obj, name):
     mat.blend_method = 'HASHED'
     obj.data.materials.append(mat)
     return mat
+
+
+
+def blendPath(path):
+  """
+  Converts a relitive path to an asset in a blender libary
+  to an absolute path to the blend,
+  the location of the asset in the blend
+  and the name of the asset.
+  
+  path, location, name
+  """
+  blendPath, dirName, assetName = ( part.strip() for part in path.rsplit('/', 2) )
+  return blendPath, dirName, assetName
+
+
+
+def blendMatSave(path, fake_user=False):
+  """
+  Save the second material on the active object
+  to a blend file.
+  This writes into the file.
+  It dose not overwrite it,
+  but may overwrite something already in it.
+  """
+  import bpy
+  path += '.mat.blend'
+  path = bpy.path.abspath('//'+path)
+  obj = bpy.context.active_object
+  mat = obj.material_slots[1].material
+  # May need to be more carfull with overwrites.
+  bpy.data.libraries.write(path, {mat}, fake_user=fake_user)
+  print('Wrote blend file into:', path)
+  
+
+
+def blendMatLoad(path):
+  """
+  Load a materiral from a blend file determined by path
+  to a new material slot.
+  """
+  path, dirName, assetName = blendPath(path)
+  print('Loading material @: ', path, dirName, assetName)
+  with bpy.data.libraries.load(path) as (inBasket, outBasket):
+    # Weird syntax.
+    setattr(outBasket, dirName, [assetName])
+
+  mat = getattr(outBasket, dirName)[0]
+  mat.make_local()
+  obj = bpy.context.active_object
+  obj.data.materials.append(mat)
+


### PR DESCRIPTION
When you push the Create Material button it saves the material in the second material slot to a blend.  It also adds the blendMaterial entry to the mhmat file.  When you Import a material, it adds the material listed in the blendMaterial entry to the second material slot.  The second material slot is used for both importing and exporting to ensure that the mhmat material and the blend material are allowed to be independent of each other.