### PR TITLE
Fixed blendMaterial mhmat entry being to long.

### DIFF
--- a/makeskin/operators/writematerial.py
+++ b/makeskin/operators/writematerial.py
@@ -87,12 +87,11 @@ class MHS_OT_WriteMaterialOperator(bpy.types.Operator, ExportHelper):
               msg = "Object dose not have a second material."
               self.report({'ERROR'}, msg)
               raise IndexError(msg)
-
-            fileName = bpy.path.relpath(self.filepath).strip('//').rstrip('.mhmat')
-            # Make shure its materials with an s :(
-            path = fileName+'.mat.blend/materials/'+matName
-            mhmat.settings["blendMaterial"] = path
-            blendMatSave(fileName)
+            
+            from pathlib import Path
+            path = Path(fnAbsolute).with_suffix('.mat.blend')
+            mhmat.settings["blendMaterial"] = path.name+'/materials/'+matName
+            blendMatSave(path)
 
 
         with open(fnAbsolute,'w') as f:

--- a/makeskin/utils.py
+++ b/makeskin/utils.py
@@ -40,12 +40,10 @@ def blendMatSave(path, fake_user=False):
   but may overwrite something already in it.
   """
   import bpy
-  path += '.mat.blend'
-  path = bpy.path.abspath('//'+path)
   obj = bpy.context.active_object
   mat = obj.material_slots[1].material
   # May need to be more carfull with overwrites.
-  bpy.data.libraries.write(path, {mat}, fake_user=fake_user)
+  bpy.data.libraries.write(str(path), {mat}, fake_user=fake_user)
   print('Wrote blend file into:', path)
   
 


### PR DESCRIPTION
The blend file should now be placed in the same directory as the mhmat and should be listed relatively, as intended.  The mhmat entry now should look something like this "blendMaterial makeskin.mat.blend/materials/Material.006".  Note that "materials" is the path in the blend file and "Material.006" is the materials name.  Neither are os paths and both are case sensitive.