### PR TITLE
Make compatible with Blender 4.3

### DIFF
--- a/makeskin/material.py
+++ b/makeskin/material.py
@@ -146,7 +146,7 @@ class MHMat:
         sett["diffuseColor"] = [diffuseColor[0], diffuseColor[1], diffuseColor[2]]
 
         sett["emissiveColor"] = None
-        col = nh.getPrincipledSocketDefaultValue("Emission")
+        col = nh.getPrincipledSocketDefaultValue(27)
         if col:
             if col[0] < 0.01 and col[1] < 0.01 and col[2] < 0.01:
                 pass # emission is black


### PR DESCRIPTION
Fixes a crash in Blender 4.3 caused by the Emission input of the Principled BSDF shader being put inside a dropdown menu. As far as I can tell, inputs inside dropdown menus cannot be queried by name, so here it is queried by its number(27).